### PR TITLE
Redesign homepage with terminal-themed hero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 .DS_Store
 .astro
+dist
+.netlify

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ import react from "@astrojs/react";
 import netlify from "@astrojs/netlify";
 
 export default defineConfig({
+  site: "https://xaaha.dev",
   integrations: [icon(), mdx(), react()],
 
   markdown: {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -25,6 +25,8 @@ const mailTo = `mailto:${email}`;
     border-top: 1px solid hsl(var(--txt) / 0.08);
     margin-top: var(--space-3xl, 4rem);
     padding: var(--space-lg) var(--space-md);
+    background-color: transparent;
+    box-shadow: none;
   }
 
   .site-footer__inner {
@@ -34,8 +36,10 @@ const mailTo = `mailto:${email}`;
     flex-direction: column;
     align-items: center;
     gap: var(--space-sm);
+    font-family: "IBM Plex Mono", monospace;
     font-size: var(--fs-sm);
-    color: hsl(var(--txt) / 0.6);
+    color: hsl(var(--txt) / 0.5);
+    letter-spacing: 0.01em;
   }
 
   .site-footer__socials {
@@ -47,7 +51,7 @@ const mailTo = `mailto:${email}`;
   }
 
   .site-footer__socials a {
-    color: hsl(var(--txt) / 0.7);
+    color: hsl(var(--txt) / 0.6);
     text-decoration: none;
   }
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -36,7 +36,6 @@ const mailTo = `mailto:${email}`;
     flex-direction: column;
     align-items: center;
     gap: var(--space-sm);
-    font-family: "IBM Plex Mono", monospace;
     font-size: var(--fs-sm);
     color: hsl(var(--txt) / 0.5);
     letter-spacing: 0.01em;

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -93,7 +93,6 @@ const navData: {
 <style>
   /* recede chrome so the terminal stays center stage */
   nav[aria-label="Primary"] {
-    font-family: "IBM Plex Mono", monospace;
     background-color: transparent;
     box-shadow: none;
   }

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -91,6 +91,23 @@ const navData: {
 </nav>
 
 <style>
+  /* recede chrome so the terminal stays center stage */
+  nav[aria-label="Primary"] {
+    font-family: "IBM Plex Mono", monospace;
+    background-color: transparent;
+    box-shadow: none;
+  }
+
+  nav[aria-label="Primary"] :global(a) {
+    color: hsl(var(--txt) / 0.6);
+    font-size: var(--fs-sm);
+    letter-spacing: 0.01em;
+  }
+
+  nav[aria-label="Primary"] :global(a:hover) {
+    color: hsl(var(--accent));
+  }
+
   .desktop-nav {
     display: flex;
     align-items: center;

--- a/src/data/indexData.ts
+++ b/src/data/indexData.ts
@@ -4,17 +4,36 @@ export const linkedin = "https://www.linkedin.com/in/pthapa1";
 
 export const bio = {
   title: "xaaha | Software Engineer",
-  prompt: "whoami",
   name: "xaaha",
-  status: "Currently shipping",
-  role: "Solo engineer. I build software and developer tools.",
-  focusLeadIn: "Currently working on",
+  role: "Five years of CLI obsession. Hand-rolled software and developer tools.",
+  mailArg: "let's-work-together",
   focusProject: {
     name: "Hulak",
     url: "https://github.com/xaaha/hulak",
-    tagline:
-      "a fast, no-fuss CLI API client for the terminal. I like simple software, fast workflows, and good tooling.",
+    tap: "xaaha/tap/hulak",
   },
-  notesAsideTitle: "Recent notes",
-  notesAllLabel: "All notes",
+  sections: {
+    shipping: "what I'm shipping",
+    alsoShipped: "also shipped",
+  },
+  notesAsideTitle: "recent notes",
+  notesAllLabel: "all notes",
 };
+
+export const selectedWork = [
+  {
+    slug: "sheet-happens",
+    url: "https://sh.xaaha.dev",
+    blurb: "TanStack · Amazon Ads bulk launch sheets",
+  },
+  {
+    slug: "address-api",
+    url: "https://github.com/xaaha/address-api",
+    blurb: "Go · GraphQL · 20k real-world addresses by country",
+  },
+  {
+    slug: "tldrnotes",
+    url: "https://github.com/xaaha/tldrnotes",
+    blurb: "Astro · this site",
+  },
+];

--- a/src/data/indexData.ts
+++ b/src/data/indexData.ts
@@ -14,26 +14,7 @@ export const bio = {
   },
   sections: {
     shipping: "what I'm shipping",
-    alsoShipped: "also shipped",
   },
   notesAsideTitle: "recent notes",
   notesAllLabel: "all notes",
 };
-
-export const selectedWork = [
-  {
-    slug: "sheet-happens",
-    url: "https://sh.xaaha.dev",
-    blurb: "TanStack · Amazon Ads bulk launch sheets",
-  },
-  {
-    slug: "address-api",
-    url: "https://github.com/xaaha/address-api",
-    blurb: "Go · GraphQL · 20k real-world addresses by country",
-  },
-  {
-    slug: "tldrnotes",
-    url: "https://github.com/xaaha/tldrnotes",
-    blurb: "Astro · this site",
-  },
-];

--- a/src/data/indexData.ts
+++ b/src/data/indexData.ts
@@ -4,7 +4,10 @@ export const linkedin = "https://www.linkedin.com/in/pthapa1";
 
 export const bio = {
   title: "xaaha | Software Engineer",
-  intro: "I’m Xaaha. I build software and developer tools.",
+  prompt: "whoami",
+  name: "xaaha",
+  status: "Currently shipping",
+  role: "Solo engineer. I build software and developer tools.",
   focusLeadIn: "Currently working on",
   focusProject: {
     name: "Hulak",

--- a/src/data/indexData.ts
+++ b/src/data/indexData.ts
@@ -5,7 +5,7 @@ export const linkedin = "https://www.linkedin.com/in/pthapa1";
 export const bio = {
   title: "xaaha | Software Engineer",
   name: "xaaha",
-  role: "Five years of CLI obsession. Hand-rolled software and developer tools.",
+  role: "Building software that's fast, reliable, and pleasure to use",
   mailArg: "let's-work-together",
   focusProject: {
     name: "Hulak",

--- a/src/icons/chevron-right.svg
+++ b/src/icons/chevron-right.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+    <polyline points="9 6 15 12 9 18"/>
+  </g>
+</svg>

--- a/src/layouts/MainHead.astro
+++ b/src/layouts/MainHead.astro
@@ -1,5 +1,7 @@
 ---
-const { title, description } = Astro.props;
+const { title, description, image = "/og-image.png" } = Astro.props;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
+const imageUrl = new URL(image, Astro.site).href;
 ---
 
 <head>
@@ -15,6 +17,21 @@ const { title, description } = Astro.props;
   <meta name="generator" content={Astro.generator} />
   <title>{title}</title>
   <meta name="description" content={description} />
+  <link rel="canonical" href={canonicalUrl} />
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content={canonicalUrl} />
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={description} />
+  <meta property="og:image" content={imageUrl} />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content={canonicalUrl} />
+  <meta name="twitter:title" content={title} />
+  <meta name="twitter:description" content={description} />
+  <meta name="twitter:image" content={imageUrl} />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link

--- a/src/layouts/MainHead.astro
+++ b/src/layouts/MainHead.astro
@@ -1,7 +1,7 @@
 ---
-const { title, description, image = "/og-image.png" } = Astro.props;
+const { title, description, image } = Astro.props;
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
-const imageUrl = new URL(image, Astro.site).href;
+const imageUrl = image ? new URL(image, Astro.site).href : undefined;
 ---
 
 <head>
@@ -24,14 +24,17 @@ const imageUrl = new URL(image, Astro.site).href;
   <meta property="og:url" content={canonicalUrl} />
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
-  <meta property="og:image" content={imageUrl} />
+  {imageUrl && <meta property="og:image" content={imageUrl} />}
 
   <!-- Twitter -->
-  <meta name="twitter:card" content="summary_large_image" />
+  <meta
+    name="twitter:card"
+    content={imageUrl ? "summary_large_image" : "summary"}
+  />
   <meta name="twitter:url" content={canonicalUrl} />
   <meta name="twitter:title" content={title} />
   <meta name="twitter:description" content={description} />
-  <meta name="twitter:image" content={imageUrl} />
+  {imageUrl && <meta name="twitter:image" content={imageUrl} />}
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -172,7 +172,6 @@ const recentNotes = allNotes
   /* terminal body */
   .term__body {
     padding: var(--space-md);
-    font-family: "IBM Plex Mono", monospace;
     line-height: 1.6;
   }
 
@@ -259,13 +258,17 @@ const recentNotes = allNotes
     font-weight: 700;
   }
 
-  .term__divider::after {
+  .term__divider::after,
+  .notes-aside__title::after {
     content: "";
     flex: 1;
-    border-top: 1px dashed hsl(var(--t-text-dim) / 0.6);
-    align-self: center;
+    border-top: 1px dashed;
     margin-left: 0.5ch;
     margin-top: 0.15em;
+  }
+
+  .term__divider::after {
+    border-top-color: hsl(var(--t-text-dim) / 0.6);
   }
 
   /* brew install lines */
@@ -360,9 +363,9 @@ const recentNotes = allNotes
     line-height: 1;
   }
 
-  .term__success-name {
+  .term__success-name,
+  .term__mail-arg {
     color: hsl(var(--t-accent));
-    font-weight: 700;
     background-image: linear-gradient(
       hsl(var(--t-accent)),
       hsl(var(--t-accent))
@@ -373,7 +376,16 @@ const recentNotes = allNotes
     transition: background-size var(--transition-ease-fast);
   }
 
-  .term__success:hover .term__success-name {
+  .term__success-name {
+    font-weight: 700;
+  }
+
+  .term__mail-arg {
+    font-weight: 600;
+  }
+
+  .term__success:hover .term__success-name,
+  .term__mail:hover .term__mail-arg {
     background-size: 100% 2px;
   }
 
@@ -407,23 +419,6 @@ const recentNotes = allNotes
     padding: 0.4em 0;
     margin-top: var(--space-sm);
     width: fit-content;
-  }
-
-  .term__mail-arg {
-    color: hsl(var(--t-accent));
-    font-weight: 600;
-    background-image: linear-gradient(
-      hsl(var(--t-accent)),
-      hsl(var(--t-accent))
-    );
-    background-repeat: no-repeat;
-    background-size: 100% 1px;
-    background-position: 0 100%;
-    transition: background-size var(--transition-ease-fast);
-  }
-
-  .term__mail:hover .term__mail-arg {
-    background-size: 100% 2px;
   }
 
   /* active prompt cursor */
@@ -465,7 +460,6 @@ const recentNotes = allNotes
 
   /* notes sidebar — muted page chrome, recedes so terminal stays focus */
   .notes-aside {
-    font-family: "IBM Plex Mono", monospace;
     font-size: var(--fs-sm);
   }
 
@@ -487,11 +481,7 @@ const recentNotes = allNotes
   }
 
   .notes-aside__title::after {
-    content: "";
-    flex: 1;
-    border-top: 1px dashed hsl(var(--txt) / 0.15);
-    margin-left: 0.5ch;
-    margin-top: 0.15em;
+    border-top-color: hsl(var(--txt) / 0.15);
   }
 
   .notes-aside__list {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,23 @@ const recentNotes = allNotes
 <Mainlayout title={bio.title}>
   <div class="home container">
     <section class="bio" aria-label="About">
-      <p class="bio__intro">{bio.intro}</p>
+      <div class="bio__terminal" aria-hidden="true">
+        <div class="bio__cmd">
+          <span class="bio__prompt">$</span>
+          <span class="bio__cmd-text">{bio.prompt}</span>
+        </div>
+        <div class="bio__output">
+          <span class="bio__arrow">&gt;</span>
+          <span class="bio__name">{bio.name}</span><span class="bio__cursor"
+          ></span>
+          <span class="bio__status">
+            <span class="bio__status-dot"></span>
+            {bio.status}
+          </span>
+        </div>
+      </div>
+
+      <p class="bio__role">{bio.role}</p>
 
       <p class="bio__focus">
         {bio.focusLeadIn}{" "}
@@ -64,7 +80,110 @@ const recentNotes = allNotes
     max-width: 60ch;
   }
 
-  .bio__intro {
+  .bio__terminal {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    padding: var(--space-sm) var(--space-md);
+    background-color: hsl(var(--muted));
+    border: 1px solid hsl(var(--txt) / 0.08);
+    border-left: 3px solid hsl(var(--accent));
+    border-radius: var(--radius-md);
+    font-family: "IBM Plex Mono", monospace;
+    box-shadow: var(--shadow-sm);
+  }
+
+  .bio__cmd {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6ch;
+    font-size: var(--fs-base);
+    color: hsl(var(--txt) / 0.6);
+  }
+
+  .bio__prompt {
+    color: hsl(var(--accent));
+    font-weight: 700;
+  }
+
+  .bio__cmd-text {
+    color: hsl(var(--txt) / 0.85);
+  }
+
+  .bio__output {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.6ch;
+    font-size: var(--fs-lg);
+    line-height: 1.2;
+  }
+
+  .bio__arrow {
+    color: hsl(var(--accent));
+    font-weight: 700;
+  }
+
+  .bio__name {
+    color: hsl(var(--txt));
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
+
+  .bio__cursor {
+    display: inline-block;
+    width: 0.55ch;
+    height: 1em;
+    background-color: hsl(var(--accent));
+    transform: translateY(0.12em);
+    animation: bio-cursor-blink 1.05s steps(2, end) infinite;
+  }
+
+  @keyframes bio-cursor-blink {
+    0%,
+    50% {
+      opacity: 1;
+    }
+    50.01%,
+    100% {
+      opacity: 0;
+    }
+  }
+
+  .bio__status {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5ch;
+    font-size: var(--fs-sm);
+    color: hsl(var(--txt) / 0.75);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 500;
+  }
+
+  .bio__status-dot {
+    width: 0.6em;
+    height: 0.6em;
+    border-radius: var(--radius-full);
+    background-color: hsl(145, 63%, 48%);
+    box-shadow: 0 0 0 0 hsl(145, 63%, 48% / 0.6);
+    animation: bio-status-pulse 2s ease-out infinite;
+  }
+
+  @keyframes bio-status-pulse {
+    0% {
+      box-shadow: 0 0 0 0 hsl(145, 63%, 48% / 0.55);
+    }
+    70% {
+      box-shadow: 0 0 0 0.55em hsl(145, 63%, 48% / 0);
+    }
+    100% {
+      box-shadow: 0 0 0 0 hsl(145, 63%, 48% / 0);
+    }
+  }
+
+  .bio__role {
     font-size: var(--fs-lg);
     color: hsl(var(--txt));
     line-height: 1.4;
@@ -167,7 +286,11 @@ const recentNotes = allNotes
       align-items: start;
     }
 
-    .bio__intro {
+    .bio__role {
+      font-size: var(--fs-xl);
+    }
+
+    .bio__output {
       font-size: var(--fs-xl);
     }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,12 @@
 ---
 import Mainlayout from "@layouts/Mainlayout.astro";
+import { Icon } from "astro-icon/components";
 import { bio, email } from "../../src/data/indexData";
 import { getCollection } from "astro:content";
 
 const mailTo = `mailto:${email}`;
-const { focusProject } = bio;
+const { focusProject, sections } = bio;
+const repoPath = focusProject.url.replace(/^https?:\/\//, "");
 
 const allNotes = await getCollection("notes", ({ data }) => !data.draft);
 const recentNotes = allNotes
@@ -13,232 +15,483 @@ const recentNotes = allNotes
 ---
 
 <Mainlayout title={bio.title}>
+  <script is:inline>
+    if (sessionStorage.getItem("xaaha-seen")) {
+      document.documentElement.classList.add("term-seen");
+    } else {
+      sessionStorage.setItem("xaaha-seen", "1");
+    }
+  </script>
+
   <div class="home container">
-    <section class="bio" aria-label="About">
-      <div class="bio__terminal" aria-hidden="true">
-        <div class="bio__cmd">
-          <span class="bio__prompt">$</span>
-          <span class="bio__cmd-text">{bio.prompt}</span>
+    <section class="term" aria-label="About">
+      <div class="term__body">
+        <!-- PAST: whoami + name + role -->
+        <div class="term__section--past">
+          <div class="term__block term__reveal" style="--rd: 100ms">
+            <div class="term__cmd" aria-hidden="true">
+              <span class="term__prompt">$</span>
+              <span class="term__cmd-text">whoami</span>
+            </div>
+          </div>
+          <div class="term__output">
+            <h1 class="term__name term__reveal" style="--rd: 220ms">
+              {bio.name}
+            </h1>
+            <p class="term__role term__reveal" style="--rd: 340ms">
+              <span class="term__comment-mark" aria-hidden="true">#</span>
+              {bio.role}
+            </p>
+          </div>
         </div>
-        <div class="bio__output">
-          <span class="bio__arrow">&gt;</span>
-          <span class="bio__name">{bio.name}</span><span class="bio__cursor"
-          ></span>
-          <span class="bio__status">
-            <span class="bio__status-dot"></span>
-            {bio.status}
-          </span>
+
+        <!-- PRESENT: currently shipping -->
+        <div>
+          <h2 class="term__divider term__reveal" style="--rd: 540ms">
+            <span class="term__divider-hash" aria-hidden="true">#</span>
+            {sections.shipping}
+          </h2>
+          <div class="term__block term__reveal" style="--rd: 660ms">
+            <div class="term__cmd" aria-hidden="true">
+              <span class="term__prompt">$</span>
+              <span class="term__cmd-text">brew install {focusProject.tap}</span
+              >
+            </div>
+          </div>
+          <div class="term__output">
+            <div
+              class="term__line term__reveal"
+              style="--rd: 780ms"
+              aria-hidden="true"
+            >
+              <span class="term__marker">==&gt;</span>
+              <span>Tapping xaaha/tap</span>
+            </div>
+            <div class="term__install-result term__reveal" style="--rd: 900ms">
+              <div class="term__progress" aria-hidden="true">
+                ################################################################################
+              </div>
+              <a
+                class="term__success"
+                href={focusProject.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="term__success-emoji" aria-hidden="true">🍺</span>
+                <span class="term__success-name">{focusProject.name}</span>
+                <span class="term__success-arrow" aria-hidden="true">→</span>
+                <span class="term__success-path">{repoPath}</span>
+              </a>
+            </div>
+          </div>
         </div>
+
+        <!-- ACTIVE: mail prompt -->
+        <a class="term__mail term__reveal" style="--rd: 1100ms" href={mailTo}>
+          <div class="term__cmd">
+            <span class="term__prompt" aria-hidden="true">$</span>
+            <span class="term__cmd-text"
+              >mail <span class="term__mail-arg">{bio.mailArg}</span><span
+                class="term__cursor"
+                aria-hidden="true"></span></span
+            >
+          </div>
+        </a>
       </div>
-
-      <p class="bio__role">{bio.role}</p>
-
-      <p class="bio__focus">
-        {bio.focusLeadIn}{" "}
-        <a
-          class="bio__focus-link"
-          href={focusProject.url}
-          target="_blank"
-          rel="noopener noreferrer">{focusProject.name}</a
-        >, {focusProject.tagline}
-      </p>
-
-      <p class="bio__contact">
-        Reach me at <a class="bio__contact-link" href={mailTo}>{email}</a>.
-      </p>
     </section>
 
     <aside class="notes-aside" aria-label="Recent notes">
-      <h2 class="notes-aside__title">{bio.notesAsideTitle}</h2>
+      <h2 class="notes-aside__title">
+        <span class="notes-aside__hash" aria-hidden="true">#</span>
+        {bio.notesAsideTitle}
+      </h2>
       <ul class="notes-aside__list">
         {
           recentNotes.map((note) => (
             <li class="notes-aside__item">
               <a class="notes-aside__link" href={`/notes/${note.id}/`}>
-                {note.data.title}
+                <span class="notes-aside__link-text">{note.data.title}</span>
+                <Icon
+                  name="chevron-right"
+                  class="notes-aside__chevron"
+                  aria-hidden="true"
+                />
               </a>
             </li>
           ))
         }
       </ul>
-      <a class="notes-aside__all" href="/notes/">{bio.notesAllLabel} →</a>
+      <a class="notes-aside__all" href="/notes/">
+        <span>{bio.notesAllLabel}</span>
+        <Icon
+          name="chevron-right"
+          class="notes-aside__chevron"
+          aria-hidden="true"
+        />
+      </a>
     </aside>
   </div>
 </Mainlayout>
 
 <style>
   .home {
+    width: 100%;
     display: grid;
     grid-template-columns: 1fr;
-    gap: var(--space-2xl);
+    gap: var(--space-xl);
+    align-items: start;
   }
 
-  .bio {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-md);
-    max-width: 60ch;
+  @media (--md) {
+    .home {
+      grid-template-columns: minmax(0, 1fr) 16rem;
+      gap: var(--space-2xl);
+    }
   }
 
-  .bio__terminal {
+  /* terminal window — dark palette, regardless of site theme */
+  .term {
+    --t-bg: 220 16% 11%;
+    --t-text: 220 14% 92%;
+    --t-text-muted: 220 8% 62%;
+    --t-text-dim: 220 8% 42%;
+    --t-prompt: 130 55% 66%;
+    --t-accent: 28 95% 64%;
+    --t-border: 220 16% 20%;
+
+    width: 100%;
+    max-width: 88ch;
+    background-color: hsl(var(--t-bg));
+    color: hsl(var(--t-text));
+    border: 1px solid hsl(var(--t-border));
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    box-shadow: 0 10px 28px hsl(0 0% 0% / 0.35);
+  }
+
+  /* terminal body */
+  .term__body {
+    padding: var(--space-md);
+    font-family: "IBM Plex Mono", monospace;
+    line-height: 1.6;
+  }
+
+  .term__body > :first-child {
+    margin-block-start: 0;
+  }
+
+  .term__section--past {
+    opacity: 0.88;
+  }
+
+  /* a section block (command + output) */
+  .term__block {
     display: flex;
     flex-direction: column;
     gap: var(--space-2xs);
-    padding: var(--space-sm) var(--space-md);
-    background-color: hsl(var(--muted));
-    border: 1px solid hsl(var(--txt) / 0.08);
-    border-left: 3px solid hsl(var(--accent));
-    border-radius: var(--radius-md);
-    font-family: "IBM Plex Mono", monospace;
-    box-shadow: var(--shadow-sm);
   }
 
-  .bio__cmd {
+  .term__cmd {
     display: flex;
     align-items: baseline;
-    gap: 0.6ch;
+    flex-wrap: wrap;
+    gap: 0.7ch;
     font-size: var(--fs-base);
-    color: hsl(var(--txt) / 0.6);
+    color: hsl(var(--t-text));
   }
 
-  .bio__prompt {
-    color: hsl(var(--accent));
+  .term__prompt {
+    color: hsl(var(--t-prompt));
     font-weight: 700;
+    flex-shrink: 0;
   }
 
-  .bio__cmd-text {
-    color: hsl(var(--txt) / 0.85);
+  .term__cmd-text {
+    color: hsl(var(--t-text));
+    overflow-wrap: anywhere;
   }
 
-  .bio__output {
+  .term__output {
+    padding-left: 1.7ch;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
+    margin-top: var(--space-2xs);
+  }
+
+  .term__name {
+    font-size: var(--fs-xl);
+    font-weight: 700;
+    color: hsl(var(--t-text));
+    letter-spacing: 0.02em;
+    line-height: 1.1;
+  }
+
+  .term__role {
+    display: flex;
+    align-items: baseline;
+    gap: 0.7ch;
+    margin: 0;
+    font-size: var(--fs-base);
+    line-height: 1.5;
+    color: hsl(var(--t-text-muted));
+  }
+
+  .term__comment-mark {
+    color: hsl(var(--t-text-dim));
+    flex-shrink: 0;
+  }
+
+  /* section dividers */
+  .term__divider {
     display: flex;
     align-items: center;
-    flex-wrap: wrap;
-    gap: 0.6ch;
-    font-size: var(--fs-lg);
-    line-height: 1.2;
-  }
-
-  .bio__arrow {
-    color: hsl(var(--accent));
-    font-weight: 700;
-  }
-
-  .bio__name {
-    color: hsl(var(--txt));
-    font-weight: 700;
+    gap: 1ch;
+    margin-block: var(--space-lg) var(--space-sm);
+    font-size: var(--fs-sm);
+    font-weight: 500;
+    color: hsl(var(--t-text-muted));
     letter-spacing: 0.02em;
   }
 
-  .bio__cursor {
-    display: inline-block;
-    width: 0.55ch;
-    height: 1em;
-    background-color: hsl(var(--accent));
-    transform: translateY(0.12em);
-    animation: bio-cursor-blink 1.05s steps(2, end) infinite;
+  .term__divider-hash {
+    color: hsl(var(--t-text-dim));
+    font-weight: 700;
   }
 
-  @keyframes bio-cursor-blink {
-    0%,
-    50% {
+  .term__divider::after {
+    content: "";
+    flex: 1;
+    border-top: 1px dashed hsl(var(--t-text-dim) / 0.6);
+    align-self: center;
+    margin-left: 0.5ch;
+    margin-top: 0.15em;
+  }
+
+  /* brew install lines */
+  .term__line {
+    display: flex;
+    gap: 0.7ch;
+    font-size: var(--fs-sm);
+    color: hsl(var(--t-text-muted));
+  }
+
+  .term__marker {
+    color: hsl(var(--t-prompt));
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  .term__install-result {
+    display: grid;
+    grid-template-areas: "slot";
+    min-height: 1.6em;
+    margin-top: var(--space-2xs);
+  }
+
+  .term__progress,
+  .term__success {
+    grid-area: slot;
+  }
+
+  .term__progress {
+    width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    color: hsl(var(--t-text-dim));
+    font-weight: 600;
+    font-size: var(--fs-sm);
+    line-height: 1.6;
+    letter-spacing: -0.06em;
+    clip-path: inset(0 100% 0 0);
+    animation: term-progress 4s cubic-bezier(0.4, 0, 0.2, 1) var(--rd, 0ms)
+      forwards;
+  }
+
+  @keyframes term-progress {
+    0% {
+      clip-path: inset(0 100% 0 0);
       opacity: 1;
     }
-    50.01%,
+    75% {
+      clip-path: inset(0 0 0 0);
+      opacity: 1;
+    }
+    85% {
+      clip-path: inset(0 0 0 0);
+      opacity: 0;
+    }
     100% {
+      clip-path: inset(0 0 0 0);
       opacity: 0;
     }
   }
 
-  .bio__status {
-    margin-left: auto;
+  .term__success {
     display: inline-flex;
-    align-items: center;
-    gap: 0.5ch;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.6ch;
+    padding: 0.15em 0;
+    text-decoration: none;
+    color: hsl(var(--t-text));
     font-size: var(--fs-sm);
-    color: hsl(var(--txt) / 0.75);
-    text-transform: uppercase;
-    letter-spacing: 0.12em;
-    font-weight: 500;
+    width: fit-content;
+    opacity: 0;
+    pointer-events: none;
+    animation: term-success 4s linear var(--rd, 0ms) forwards;
   }
 
-  .bio__status-dot {
-    width: 0.6em;
-    height: 0.6em;
-    border-radius: var(--radius-full);
-    background-color: hsl(145, 63%, 48%);
-    box-shadow: 0 0 0 0 hsl(145, 63%, 48% / 0.6);
-    animation: bio-status-pulse 2s ease-out infinite;
-  }
-
-  @keyframes bio-status-pulse {
-    0% {
-      box-shadow: 0 0 0 0 hsl(145, 63%, 48% / 0.55);
+  @keyframes term-success {
+    0%,
+    80% {
+      opacity: 0;
+      pointer-events: none;
     }
-    70% {
-      box-shadow: 0 0 0 0.55em hsl(145, 63%, 48% / 0);
-    }
+    95%,
     100% {
-      box-shadow: 0 0 0 0 hsl(145, 63%, 48% / 0);
+      opacity: 1;
+      pointer-events: auto;
     }
   }
 
-  .bio__role {
-    font-size: var(--fs-lg);
-    color: hsl(var(--txt));
-    line-height: 1.4;
-    font-weight: 500;
+  .term__success-emoji {
+    font-size: 1.05em;
+    line-height: 1;
   }
 
-  .bio__focus {
-    font-size: var(--fs-base);
-    color: hsl(var(--txt) / 0.8);
-    line-height: 1.65;
+  .term__success-name {
+    color: hsl(var(--t-accent));
+    font-weight: 700;
+    background-image: linear-gradient(
+      hsl(var(--t-accent)),
+      hsl(var(--t-accent))
+    );
+    background-repeat: no-repeat;
+    background-size: 100% 1px;
+    background-position: 0 100%;
+    transition: background-size var(--transition-ease-fast);
   }
 
-  .bio__focus-link {
-    color: hsl(var(--accent));
-    font-weight: 600;
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
+  .term__success:hover .term__success-name {
+    background-size: 100% 2px;
   }
 
-  .bio__focus-link:hover {
+  .term__success-arrow {
+    color: hsl(var(--t-text-dim));
+    display: inline-block;
+    transition:
+      transform var(--transition-ease-fast),
+      color var(--transition-ease-fast);
+  }
+
+  .term__success:hover .term__success-arrow {
+    transform: translateX(3px);
+    color: hsl(var(--t-accent));
+  }
+
+  .term__success-path {
+    color: hsl(var(--t-text-muted));
+    transition: color var(--transition-ease-fast);
+  }
+
+  .term__success:hover .term__success-path {
+    color: hsl(var(--t-text));
+  }
+
+  /* mail CTA — active prompt */
+  .term__mail {
+    display: block;
     text-decoration: none;
-  }
-
-  .bio__contact {
-    font-size: var(--fs-base);
-    color: hsl(var(--txt) / 0.7);
-    line-height: 1.65;
+    color: inherit;
+    padding: 0.4em 0;
     margin-top: var(--space-sm);
+    width: fit-content;
   }
 
-  .bio__contact-link {
-    color: hsl(var(--accent));
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
+  .term__mail-arg {
+    color: hsl(var(--t-accent));
+    font-weight: 600;
+    background-image: linear-gradient(
+      hsl(var(--t-accent)),
+      hsl(var(--t-accent))
+    );
+    background-repeat: no-repeat;
+    background-size: 100% 1px;
+    background-position: 0 100%;
+    transition: background-size var(--transition-ease-fast);
   }
 
-  .bio__contact-link:hover {
-    text-decoration: none;
+  .term__mail:hover .term__mail-arg {
+    background-size: 100% 2px;
   }
 
+  /* active prompt cursor */
+  .term__cursor {
+    display: inline-block;
+    width: 0.62ch;
+    height: 1.6em;
+    background-color: hsl(var(--t-text));
+    vertical-align: -0.44em;
+    margin-left: 0.8ch;
+    animation: term-cursor-blink 1.05s step-end infinite;
+  }
+
+  @keyframes term-cursor-blink {
+    50% {
+      opacity: 0;
+    }
+  }
+
+  /* top-to-bottom reveal */
+  .term__reveal {
+    opacity: 0;
+    transform: translateY(4px);
+    animation: term-reveal 360ms ease-out var(--rd, 0ms) both;
+  }
+
+  @keyframes term-reveal {
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @media (--sm) {
+    .term__name {
+      font-size: var(--fs-2xl);
+    }
+  }
+
+  /* notes sidebar — muted page chrome, recedes so terminal stays focus */
   .notes-aside {
-    border-top: 1px solid hsl(var(--txt) / 0.1);
-    padding-top: var(--space-lg);
+    font-family: "IBM Plex Mono", monospace;
+    font-size: var(--fs-sm);
   }
 
   .notes-aside__title {
-    display: inline-block;
-    font-size: var(--fs-md);
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: hsl(var(--accent));
+    display: flex;
+    align-items: center;
+    gap: 1ch;
+    font-size: var(--fs-sm);
+    font-weight: 600;
+    color: hsl(var(--txt) / 0.55);
+    text-transform: none;
+    letter-spacing: 0.02em;
+    margin-bottom: var(--space-md);
+  }
+
+  .notes-aside__hash {
+    color: hsl(var(--txt) / 0.4);
     font-weight: 700;
-    margin-bottom: var(--space-lg);
-    padding-bottom: var(--space-2xs);
-    border-bottom: 2px solid hsl(var(--accent) / 0.4);
+  }
+
+  .notes-aside__title::after {
+    content: "";
+    flex: 1;
+    border-top: 1px dashed hsl(var(--txt) / 0.15);
+    margin-left: 0.5ch;
+    margin-top: 0.15em;
   }
 
   .notes-aside__list {
@@ -254,53 +507,90 @@ const recentNotes = allNotes
     line-height: 1.5;
   }
 
-  .notes-aside__link {
-    font-size: var(--fs-md);
-    color: hsl(var(--txt) / 0.9);
+  .notes-aside__link,
+  .notes-aside__all {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1ch;
+    color: hsl(var(--txt) / 0.7);
     text-decoration: none;
+    transition: color var(--transition-ease-fast);
   }
 
-  .notes-aside__link:hover {
+  .notes-aside__link-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .notes-aside__chevron {
+    flex-shrink: 0;
+    width: 0.9em;
+    height: 0.9em;
+    color: hsl(var(--txt) / 0.35);
+    transition:
+      transform var(--transition-ease-fast),
+      color var(--transition-ease-fast);
+  }
+
+  .notes-aside__link:hover,
+  .notes-aside__all:hover {
     color: hsl(var(--accent));
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
+  }
+
+  .notes-aside__link:hover .notes-aside__chevron,
+  .notes-aside__all:hover .notes-aside__chevron {
+    transform: translateX(2px);
+    color: hsl(var(--accent));
   }
 
   .notes-aside__all {
-    display: inline-block;
     margin-top: var(--space-md);
-    font-size: var(--fs-sm);
-    color: hsl(var(--accent));
-    text-decoration: none;
+    color: hsl(var(--txt) / 0.55);
   }
 
-  .notes-aside__all:hover {
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
-  }
-
-  @media (min-width: 900px) {
-    .home {
-      grid-template-columns: minmax(0, 1fr) 18rem;
-      gap: var(--space-3xl, 4rem);
-      align-items: start;
-    }
-
-    .bio__role {
-      font-size: var(--fs-xl);
-    }
-
-    .bio__output {
-      font-size: var(--fs-xl);
-    }
-
+  @media (--md) {
     .notes-aside {
-      border-top: none;
-      padding-top: 0;
-      border-left: 1px solid hsl(var(--txt) / 0.1);
-      padding-left: var(--space-xl);
       position: sticky;
-      top: var(--space-xl);
+      top: var(--space-md);
+    }
+  }
+
+  /* skip reveal animations on revisit — but keep the cursor blinking */
+  :global(.term-seen) .term__reveal {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+
+  :global(.term-seen) .term__progress {
+    display: none;
+  }
+
+  :global(.term-seen) .term__success {
+    opacity: 1;
+    pointer-events: auto;
+    animation: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .term__reveal,
+    .term__cursor {
+      opacity: 1;
+      transform: none;
+      animation: none;
+    }
+
+    .term__progress {
+      display: none;
+    }
+
+    .term__success {
+      opacity: 1;
+      pointer-events: auto;
+      animation: none;
     }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -72,9 +72,17 @@ h6 {
 
   /* dynamic font sizes adapted from utopia.fyi */
   --fs-sm: clamp(0.78rem, calc(0.75rem + 0.17vw), 0.88rem);
-  --fs-base: clamp(0.92rem, calc(0.82rem + 0.5vw), 1.08rem); /* between sm and md */
+  --fs-base: clamp(
+    0.92rem,
+    calc(0.82rem + 0.5vw),
+    1.08rem
+  ); /* between sm and md */
   --fs-md: clamp(1rem, calc(0.91rem + 0.43vw), 1.125rem); /*font sizing*/
-  --fs-article: clamp(0.9rem, calc(0.82rem + 0.39vw), 1.0125rem); /* 90% of fs-md for article body */
+  --fs-article: clamp(
+    0.9rem,
+    calc(0.82rem + 0.39vw),
+    1.0125rem
+  ); /* 90% of fs-md for article body */
   --fs-lg: clamp(1.35rem, calc(1.22rem + 0.64vw), 1.72rem);
   --fs-xl: clamp(1.75rem, calc(1.6rem + 0.75vw), 2rem);
   --fs-2xl: clamp(2rem, calc(2.8rem + 1.2vw), 2.4rem);
@@ -297,7 +305,7 @@ button {
     user-select: none;
   }
 
-  & (svg) {
+  & svg {
     height: var(--fs-md);
     width: var(--fs-md);
   }
@@ -402,98 +410,10 @@ button {
   }
 }
 
-/* center the button horizontally within the content cell */
-.center-contact {
-  display: flex;
-  justify-content: center;
-  margin-top: var(--space-md);
-}
-
-.about {
-  display: grid;
-  gap: var(--space-lg);
-  align-items: center;
-  margin-block: var(--space-xl);
-
-  @media (--md) {
-    grid-template-columns: 1fr 2fr;
-    place-content: center;
-    margin-block: var(--space-xl);
-  }
-
-  & img {
-    border-radius: var(--radius-full);
-    height: 400px;
-    width: min(300px, 100%);
-    box-shadow: var(--shadow-lg);
-    object-fit: cover;
-    object-position: center;
-
-    @media (--md) {
-      justify-self: end;
-    }
-  }
-
-  & .content {
-    display: grid;
-    gap: var(--space-xs);
-    max-width: var(--content-md);
-  }
-}
-
 .post-container {
   margin-block: var(--space-md);
   display: grid;
   gap: var(--space-lg);
-}
-
-/* cards */
-.card {
-  position: relative;
-  display: grid;
-  gap: var(--space-sm); /* Keep the gap for stacked content */
-  background-color: hsl(var(--muted));
-  padding: var(--space-md);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-sm);
-
-  & [aria-hidden="true"] {
-    margin-inline: calc(var(--space-md) * -1);
-    margin-block: var(--space-md);
-  }
-
-  & img {
-    box-shadow: var(--shadow-sm);
-    object-fit: cover;
-  }
-
-  & a {
-    text-decoration: none;
-  }
-
-  & .content {
-    display: grid;
-    gap: var(--space-xs);
-  }
-}
-
-/* Make other links/buttons clickable on top of the stretched link  
- * for notes card*/
-.card,
-.card .content small a {
-  position: relative;
-  z-index: 1;
-}
-
-/* This is the main link inside the card's title */
-.card .content .h3 a:after {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 0;
 }
 
 /* backtick inline code */
@@ -505,10 +425,6 @@ button {
   font-size: 0.88em;
   font-family: "IBM Plex Mono", monospace;
   font-weight: lighter;
-}
-
-.card {
-  --accent: var(--txt);
 }
 
 /* posts */
@@ -550,43 +466,6 @@ header {
   object-position: center;
   @media (--lg) {
     border-radius: var(--radius-md);
-  }
-}
-
-/* category cloud */
-.categories {
-  list-style: none;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  align-items: center;
-  justify-content: center;
-  margin: 0;
-
-  & li {
-    display: grid;
-    place-items: center;
-  }
-}
-
-[aria-label="Related posts"] {
-  padding: 0;
-  text-align: center;
-  display: grid;
-  gap: var(--space-sm);
-  justify-items: center;
-
-  & .post {
-    background-color: hsl(var(--muted));
-    padding: var(--space-xs);
-    gap: var(--space-2xs);
-    border-radius: var(--radius-sm);
-    box-shadow: var(--shadow-sm);
-    width: fit-content;
-
-    & a {
-      text-decoration: none;
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace prose bio with a terminal-styled hero (whoami / brew install / mail prompt) with reveal animations and a `sessionStorage`-gated skip on revisit
- Update `Nav`, `Footer`, and notes aside to a quieter mono-typed treatment so the terminal stays the focal point
- Add OG / Twitter / canonical meta tags in `MainHead`, and set `site` in `astro.config.mjs`
- Remove unused homepage CSS (`.about`, `.card`, `.categories`, `.center-contact`, `[aria-label="Related posts"]`) from `global.css`
- Restructure `bio` data (drop `intro` / `focusLeadIn` / `tagline`; add `name` / `role` / `mailArg` / `tap` / `sections`)

## Test plan
- [ ] Verify homepage renders and animations play on first visit, skip on subsequent visits (sessionStorage)
- [ ] Verify `prefers-reduced-motion` disables animations
- [ ] Verify OG / Twitter meta tags render correctly (note: `/og-image.png` is referenced as default but doesn't exist in `public/` yet)
- [ ] Verify `Nav` and `Footer` styling on light/dark themes
- [ ] Verify removed CSS classes aren't used anywhere else (`.post-container` is still kept since it's used in `src/pages/tags/[tag].astro`)
- [ ] Verify notes sidebar sticky behavior at `@media (--md)`